### PR TITLE
Person object is required for underwriting a business

### DIFF
--- a/api/accounts.rst.inc
+++ b/api/accounts.rst.inc
@@ -157,7 +157,7 @@ has been underwritten.
   ``person`` 
       .. cssclass:: nested1 
    
-      *optional* **object**.  
+      *required* **object**.  
           ``name`` 
               *required* **string**. Sequence of characters. 
    


### PR DESCRIPTION
Currently the docs say a person object is optional for underwriting a business. However, the API responds with "Missing required field merchant[person]" if none is specified. Changed the docs to say person object is required.
