### PR TITLE
Fix amount description formatting

### DIFF
--- a/api/debits.rst.inc
+++ b/api/debits.rst.inc
@@ -31,9 +31,9 @@ corresponding hold.
   ``amount`` 
       *optional* **integer**. If the resolving URI references a hold then this is hold amount. You can 
       always capture less than the hold amount (e.g. a partial capture). 
-      Otherwise its the maximum per debit amount for your marketplace. Value must be >= the minimum per debit ``amount`` for *your* 
-      marketplace. Value must be <= the maximum per debit ``amount`` for *your* 
-      marketplace. 
+      Otherwise its the maximum per debit amount for your marketplace. Value must be >= the minimum per debit ``amount`` for your 
+      marketplace. Value must be <= the maximum per debit ``amount`` for your 
+      marketplace.
    
   ``appears_on_statement_as`` 
       *optional* **string**. Text that will appear on the buyer's statement. Characters that can be 


### PR DESCRIPTION
Resolves #22

Removed italic styling from Create a new debit > amount > description.

em tags (.docutils dd em) have the following styles applied, `width: 100%; float: left;` This caused the emphasized words "your" to break onto separate lines and cause the description to look odd.
