### PR TITLE
Fixed late submission delivery time

### DIFF
--- a/overview/payouts.rst
+++ b/overview/payouts.rst
@@ -193,7 +193,7 @@ Submission & Delivery times
      - July 5th @ 9:00AM PT
    * - Late submission
      - Friday @ 3:30PM PT
-     - Tuesday @ 3:30PM PT
+     - Tuesday @ 9:00AM PT
 
 .. [*] Assumes that day is a working business day -- does not fall on a
        weekend or a `federal reserve holiday <bank holidays>`_.


### PR DESCRIPTION
It seemed to me that this must have been a typo. If an early Tuesday submission can deliver by 9:00AM on Wednesday, a late Friday submission should be able to deliver by 9:00am on Tuesday.
