### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 argparse
-balanced==0.11.12
+balanced==0.11.15
 decorator
 docutils==0.9.1
 html5lib==0.95


### PR DESCRIPTION
Python library is now at 0.11.15, when trying to pip install requirements 0.11.12 is not found
